### PR TITLE
feat: enable nodejs connection reuse in Lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -31,6 +31,8 @@ functions:
     handler: src/lambda.handler
     environment:
       NODE_ENV: production
+      # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
     events:
       - http:
           method: ANY


### PR DESCRIPTION
Adds performance optimisation for AWS Lambda NodeJS runtimemhttps://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html