### PR TITLE
feat(lambda): use arm64 architecture

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -21,6 +21,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs16.x
+  architecture: arm64
   memorySize: 1024
   timeout: 15
   region: us-east-1


### PR DESCRIPTION
https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/