### PR TITLE
feat(lambda): use Graviton2 ARM architecture

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-   binaryTargets = ["native", "linux-musl", "rhel-openssl-1.0.x"]
+  binaryTargets = ["native", "linux-arm64-openssl-1.0.x"]
 }
 
 datasource db {

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,6 +21,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs16.x
+  architecture: arm64
   memorySize: 1024
   timeout: 15
   region: us-east-1
@@ -44,6 +45,6 @@ functions:
       # see https://github.com/serverless/serverless-plugin-typescript/issues/170#issuecomment-1132731263
       patterns:
         - '!node_modules/.prisma/client/libquery_engine-*'
-        - 'node_modules/.prisma/client/libquery_engine-rhel-*'
+        - 'node_modules/.prisma/client/libquery_engine-linux-arm64-*'
         - '!node_modules/prisma/libquery_engine-*'
         - '!node_modules/@prisma/engines/**'


### PR DESCRIPTION
- Updates Lambda to use Graviton2 ARM processor https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html
- Updates Prisma client to use Linux ARM64 precompiled binary target 
