### PR TITLE
fix(prisma): fix prisma 5 webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,11 +67,11 @@ module.exports = (options, webpack) => {
                     {
                         context: path.resolve(__dirname, 'node_modules/.prisma/client'),
                         from: 'libquery_engine-linux-arm64-*',
-                        to: path.resolve(__dirname, 'dist/node_modules/.prisma/client'),
+                        to: path.resolve(__dirname, 'dist'),
                     },
                     {
                         from: path.resolve(__dirname, 'prisma/schema.prisma'),
-                        to: path.resolve(__dirname, 'dist/node_modules/.prisma/client'),
+                        to: path.resolve(__dirname, 'dist/schema.prisma'),
                     },
                 ],
             }),


### PR DESCRIPTION
Fixes error encountered after migration from Prisma 4 -> 5:

```
PrismaClientInitializationError: Prisma Client could not find its `schema.prisma`. This is likely caused by a bundling step, which leads to `schema.prisma` not being copied near the resulting bundle. We would appreciate if you could take the time to share some information with us.
```